### PR TITLE
feat(alphabet): adopt alphex for AF/MPNN alphabet declarations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "huggingface-hub>=0.35.3",
   "array-record>=0.8.1",
   "msgpack-numpy>=0.4.8",
+  "alphex>=0.1.0a1",
 ]
 classifiers = [
   "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
   "equinox",
   "uuid-utils",
   "safetensors",
-  "prxteinmpnn",
+  # NOTE: `prxteinmpnn` was removed 2026-08-13. The package was renamed `aminx` and no
+  # longer resolves, which made this project's requirements unsatisfiable — nothing could
+  # be installed or imported at all. It is deliberately NOT replaced with `aminx`: that
+  # would create a proteinsmc -> aminx dependency edge, which the ecosystem partition
+  # exists to flip. `scoring/mpnn.py` already guards on `find_spec("prxteinmpnn")` and
+  # degrades to unavailable, exactly as it did before this line was dropped.
   "einops>=0.8.1",
   "huggingface-hub>=0.35.3",
   "array-record>=0.8.1",

--- a/src/proteinsmc/scoring/esm.py
+++ b/src/proteinsmc/scoring/esm.py
@@ -8,7 +8,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from proteinsmc.utils.esm import load_model, remap_sequences
+from proteinsmc.utils.esm import load_model, remap_alphafold_sequences
 
 if TYPE_CHECKING:
   from jaxtyping import Array, Float, PRNGKeyArray
@@ -59,7 +59,9 @@ def make_esm_score(
         The PLL score of the sequence.
 
     """
-    sequence = remap_sequences(sequence)
+    # This package's encoders emit AlphaFold-ordered integers, so the AlphaFold entry
+    # point is the correct one here. `remap_sequences` expects ProteinMPNN ordering.
+    sequence = remap_alphafold_sequences(sequence)
     sequence = sequence[None, :]  # Add batch dimension: (1, seq_len)
     output = eqx_model(sequence)
     log_probs = jax.nn.log_softmax(output.logits, axis=-1)  # (1, seq_len, vocab_size)

--- a/src/proteinsmc/utils/constants.py
+++ b/src/proteinsmc/utils/constants.py
@@ -269,30 +269,58 @@ ESM_PAD_ID = ESM_AA_CHAR_TO_INT_MAP["<pad>"]
 ESM_EOS_ID = ESM_AA_CHAR_TO_INT_MAP["<eos>"]
 ESM_UNK_ID = ESM_AA_CHAR_TO_INT_MAP["<unk>"]
 ESM_MASK_ID = ESM_AA_CHAR_TO_INT_MAP["<mask>"]
-PROTEINMPNN_TO_ESM_AA_MAP_JAX = jnp.full(
-  AMINO_ACIDS_NUM_STATES,  # Size is based on ColabDesign's max AA int
-  ESM_UNK_ID,
-  dtype=jnp.int32,
-)
+# --- Amino-acid integer -> ESM token maps ------------------------------------------
+#
+# TWO distinct source alphabets reach ESM through this module, and conflating them
+# silently permutes every residue that is not a fixed point of the permutation. They are
+# therefore built and named separately. See
+# `.praxia/docs/research/260813_alphabet-provenance-trace.md`.
+#
+#   AlphaFold  — this package's own encoding (`restypes`, above):  ARNDCQEGHILKMFPSTWYV
+#                Produced by `string_to_int_sequence` and fed to `scoring/esm.py`.
+#   ProteinMPNN — asr's declared canonical (`asr/src/asr/alphabet.py:8`):
+#                                                                  ACDEFGHIKLMNPQRSTVWY
+#                Supplied by external callers of `utils.esm.remap_sequences`, whose
+#                docstring has always promised the ProteinMPNN scheme.
+#
+# Before 2026-08-13 a single table was built from the AlphaFold ordering while carrying
+# the ProteinMPNN name, so external callers honouring the documented contract had their
+# sequences permuted. Only A, S and T are fixed points of that permutation.
+#
+# Both tables are sized to cover every legal sequence value — including the gap/X index
+# 20 used by asr and the stop/unknown sentinel `PROTEINMPNN_X_INT` (21). The previous
+# table was length 20, so a JAX gather clamped indices 20 and 21 to Valine.
 
-# Populate the mapping
-for cd_char, cd_int in AA_CHAR_TO_INT_MAP.items():
-  if cd_char in ESM_AA_CHAR_TO_INT_MAP:
-    esm_int = ESM_AA_CHAR_TO_INT_MAP[cd_char]
-    PROTEINMPNN_TO_ESM_AA_MAP_JAX = PROTEINMPNN_TO_ESM_AA_MAP_JAX.at[cd_int].set(esm_int)
-  else:
-    msg = (
-      f"ColabDesign character '{cd_char}' (int {cd_int}) not found in "
-      f"ESM vocabulary. Mapping to UNK."
-    )
-    logger.warning(msg)
+PROTEINMPNN_RESTYPES = "ACDEFGHIKLMNPQRSTVWY"
+"""ProteinMPNN's 20-letter ordering. Distinct from `restypes`, which is AlphaFold's."""
 
-if "X" in AA_CHAR_TO_INT_MAP and "X" in ESM_AA_CHAR_TO_INT_MAP:
-  PROTEINMPNN_TO_ESM_AA_MAP_JAX = PROTEINMPNN_TO_ESM_AA_MAP_JAX.at[AA_CHAR_TO_INT_MAP["X"]].set(
-    ESM_AA_CHAR_TO_INT_MAP["X"],
-  )
-elif "X" in AA_CHAR_TO_INT_MAP:
-  # If ESM doesn't have 'X' as a regular token, map to UNK
-  PROTEINMPNN_TO_ESM_AA_MAP_JAX = PROTEINMPNN_TO_ESM_AA_MAP_JAX.at[AA_CHAR_TO_INT_MAP["X"]].set(
-    ESM_UNK_ID,
-  )
+_ESM_MAP_LEN = PROTEINMPNN_X_INT + 1
+"""Covers indices 0..21 inclusive, so no legal sequence value can clamp."""
+
+
+def _build_esm_token_map(source_alphabet: str, alphabet_name: str) -> jnp.ndarray:
+  """Build a source-alphabet-index -> ESM-token lookup table.
+
+  Every index outside `source_alphabet` — notably the gap/X index 20 and the stop
+  sentinel 21 — resolves to `<unk>` explicitly rather than by out-of-bounds clamping.
+  """
+  table = jnp.full(_ESM_MAP_LEN, ESM_UNK_ID, dtype=jnp.int32)
+  for idx, char in enumerate(source_alphabet):
+    if char in ESM_AA_CHAR_TO_INT_MAP:
+      table = table.at[idx].set(ESM_AA_CHAR_TO_INT_MAP[char])
+    else:
+      msg = (
+        f"{alphabet_name} character '{char}' (int {idx}) not found in "
+        f"ESM vocabulary. Mapping to UNK."
+      )
+      logger.warning(msg)
+  return table
+
+
+PROTEINMPNN_TO_ESM_AA_MAP_JAX = _build_esm_token_map(PROTEINMPNN_RESTYPES, "ProteinMPNN")
+"""ProteinMPNN-ordered integer -> ESM token. Matches this constant's name and the
+documented contract of `utils.esm.remap_sequences`."""
+
+ALPHAFOLD_TO_ESM_AA_MAP_JAX = _build_esm_token_map("".join(restypes), "AlphaFold")
+"""AlphaFold-ordered integer -> ESM token. This is what `scoring/esm.py` needs, because
+this package's own encoders emit AlphaFold-ordered integers."""

--- a/src/proteinsmc/utils/constants.py
+++ b/src/proteinsmc/utils/constants.py
@@ -116,7 +116,6 @@ PROTEINMPNN_X_INT = 21
 STOP_INT = PROTEINMPNN_X_INT
 UNKNOWN_AA_INT = PROTEINMPNN_X_INT
 MAX_NUC_INT = len(NUCLEOTIDES_CHAR) - 1
-AMINO_ACIDS_NUM_STATES = 20
 
 CODON_INT_TO_RES_INT_JAX = jnp.full(
   (MAX_NUC_INT + 1, MAX_NUC_INT + 1, MAX_NUC_INT + 1),
@@ -291,8 +290,12 @@ ESM_MASK_ID = ESM_AA_CHAR_TO_INT_MAP["<mask>"]
 # 20 used by asr and the stop/unknown sentinel `PROTEINMPNN_X_INT` (21). The previous
 # table was length 20, so a JAX gather clamped indices 20 and 21 to Valine.
 
-PROTEINMPNN_RESTYPES = "ACDEFGHIKLMNPQRSTVWY"
-"""ProteinMPNN's 20-letter ordering. Distinct from `restypes`, which is AlphaFold's."""
+PROTEINMPNN_RESTYPES = known.MPNN_20.symbols
+"""ProteinMPNN's 20-letter ordering. Distinct from `restypes`, which is AlphaFold's.
+
+Derived from `known.MPNN_20.symbols` (already imported above as the declared source of
+this exact ordering) rather than hand-typed, so it cannot silently drift from alphex's
+declaration. `known.MPNN_20.symbols` is a plain `str`, so this remains a plain string."""
 
 _ESM_MAP_LEN = PROTEINMPNN_X_INT + 1
 """Covers indices 0..21 inclusive, so no legal sequence value can clamp."""

--- a/src/proteinsmc/utils/constants.py
+++ b/src/proteinsmc/utils/constants.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import collections
-from venv import logger
 
 import jax.numpy as jnp
+from alphex import Alphabet, Policy, known, perm
 
 restypes = [
   "A",
@@ -298,29 +298,30 @@ _ESM_MAP_LEN = PROTEINMPNN_X_INT + 1
 """Covers indices 0..21 inclusive, so no legal sequence value can clamp."""
 
 
-def _build_esm_token_map(source_alphabet: str, alphabet_name: str) -> jnp.ndarray:
-  """Build a source-alphabet-index -> ESM-token lookup table.
+def _build_esm_token_map(source: Alphabet) -> jnp.ndarray:
+  """Build a source-alphabet-index -> ESM-token lookup table via alphex.
 
-  Every index outside `source_alphabet` — notably the gap/X index 20 and the stop
-  sentinel 21 — resolves to `<unk>` explicitly rather than by out-of-bounds clamping.
+  `alphex.perm` covers only the unambiguous 20-residue core (`source.size == 20`, no
+  specials declared on either `known.MPNN_20` or `known.AF_20`) -- it is NOT used for the
+  full 22-wide space. A full `perm(known.MPNN_GAP_X_STOP_22, known.ESM_C, ...)` delegation
+  was tried and verified to unconditionally raise `UnmappableSymbolError`: this repo's
+  index 21 conflates `SpecialKind.UNKNOWN` and `SpecialKind.STOP` at one position, while
+  `known.ESM_C` declares them at different indices (24 vs 29), and alphex's
+  destination-coincidence resolution runs before any `Policy` is consulted -- no policy
+  avoids this. See `.praxia/docs/research/260813_alphabet-provenance-trace.md`.
+
+  Indices 20 (gap/X) and 21 (stop/unknown, conflated) are therefore still hand-filled here,
+  explicitly to `<unk>`, exactly as the pre-alphex per-character implementation did.
   """
+  core = perm(source, known.ESM_C, policy=Policy.RAISE)  # shape (20,); source.size == 20
   table = jnp.full(_ESM_MAP_LEN, ESM_UNK_ID, dtype=jnp.int32)
-  for idx, char in enumerate(source_alphabet):
-    if char in ESM_AA_CHAR_TO_INT_MAP:
-      table = table.at[idx].set(ESM_AA_CHAR_TO_INT_MAP[char])
-    else:
-      msg = (
-        f"{alphabet_name} character '{char}' (int {idx}) not found in "
-        f"ESM vocabulary. Mapping to UNK."
-      )
-      logger.warning(msg)
-  return table
+  return table.at[: source.n_symbols].set(jnp.asarray(core))
 
 
-PROTEINMPNN_TO_ESM_AA_MAP_JAX = _build_esm_token_map(PROTEINMPNN_RESTYPES, "ProteinMPNN")
+PROTEINMPNN_TO_ESM_AA_MAP_JAX = _build_esm_token_map(known.MPNN_20)
 """ProteinMPNN-ordered integer -> ESM token. Matches this constant's name and the
 documented contract of `utils.esm.remap_sequences`."""
 
-ALPHAFOLD_TO_ESM_AA_MAP_JAX = _build_esm_token_map("".join(restypes), "AlphaFold")
+ALPHAFOLD_TO_ESM_AA_MAP_JAX = _build_esm_token_map(known.AF_20)
 """AlphaFold-ordered integer -> ESM token. This is what `scoring/esm.py` needs, because
 this package's own encoders emit AlphaFold-ordered integers."""

--- a/src/proteinsmc/utils/esm.py
+++ b/src/proteinsmc/utils/esm.py
@@ -28,10 +28,25 @@ if TYPE_CHECKING:
 
 
 from .constants import (
+  ALPHAFOLD_TO_ESM_AA_MAP_JAX,
   ESM_BOS_ID,
   ESM_EOS_ID,
   PROTEINMPNN_TO_ESM_AA_MAP_JAX,
 )
+
+
+def _remap_with(
+  sequence: ProteinSequence,
+  token_map: jnp.ndarray,
+) -> ProteinSequence:
+  """Gather `sequence` through `token_map` and wrap the result in BOS/EOS."""
+  return jnp.concatenate(
+    [
+      jnp.array([ESM_BOS_ID], dtype=jnp.int32),
+      token_map[sequence],
+      jnp.array([ESM_EOS_ID], dtype=jnp.int32),
+    ],
+  )
 
 
 @jax.jit
@@ -40,24 +55,45 @@ def remap_sequences(
 ) -> ProteinSequence:
   """Remap amino acid integer IDs from ProteinMPNN's scheme to ESM's token scheme.
 
-  Also add BOS/EOS tokens and pad the sequence.
+  Also adds BOS/EOS tokens.
+
+  The ProteinMPNN ordering is `ACDEFGHIKLMNPQRSTVWY`, which is **not** the ordering this
+  package's own encoders produce — those emit AlphaFold-ordered integers, for which
+  `remap_alphafold_sequences` is the correct entry point. Passing the wrong one silently
+  permutes every residue except A, S and T. Until 2026-08-13 this function's lookup table
+  was built from the AlphaFold ordering despite the contract documented here, so external
+  callers honouring the contract were mis-scored; see
+  `.praxia/docs/research/260813_alphabet-provenance-trace.md`.
 
   Args:
-      sequence: A ProteinSequence containing amino acid integer IDs.
+      sequence: A ProteinSequence of ProteinMPNN-ordered amino acid integer IDs. Indices
+        outside 0..19 (e.g. gap/X at 20, stop at 21) map explicitly to ESM's `<unk>`.
 
   Returns:
-      A tuple of (esm_amino_acid_ids, attention_mask) as JAX arrays.
+      The ESM token IDs, prefixed with BOS and suffixed with EOS.
 
   """
-  esm_aa_ints_raw = PROTEINMPNN_TO_ESM_AA_MAP_JAX[sequence]
+  return _remap_with(sequence, PROTEINMPNN_TO_ESM_AA_MAP_JAX)
 
-  return jnp.concatenate(
-    [
-      jnp.array([ESM_BOS_ID], dtype=jnp.int32),
-      esm_aa_ints_raw,
-      jnp.array([ESM_EOS_ID], dtype=jnp.int32),
-    ],
-  )
+
+@jax.jit
+def remap_alphafold_sequences(
+  sequence: ProteinSequence,
+) -> ProteinSequence:
+  """Remap AlphaFold-ordered amino acid integer IDs to ESM's token scheme.
+
+  This is the correct entry point for sequences produced inside this package, whose
+  encoders are AlphaFold-ordered (`utils.constants.restypes`).
+
+  Args:
+      sequence: A ProteinSequence of AlphaFold-ordered amino acid integer IDs. Indices
+        outside 0..19 map explicitly to ESM's `<unk>`.
+
+  Returns:
+      The ESM token IDs, prefixed with BOS and suffixed with EOS.
+
+  """
+  return _remap_with(sequence, ALPHAFOLD_TO_ESM_AA_MAP_JAX)
 
 
 class AbstractFromTorch(eqx.Module):

--- a/tests/scoring/test_esm.py
+++ b/tests/scoring/test_esm.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
 
 from proteinsmc.scoring.esm import make_esm_score
-from proteinsmc.utils.esm import remap_sequences
 
 
 # Define a mock model that simulates the behavior of the real ESM model

--- a/tests/test_alphabet_conformance.py
+++ b/tests/test_alphabet_conformance.py
@@ -40,7 +40,7 @@ def test_restypes_is_the_alphafold_ordering() -> None:
 
 
 def test_proteinmpnn_restypes_is_the_proteinmpnn_ordering() -> None:
-  assert C.PROTEINMPNN_RESTYPES == known.MPNN_20.symbols
+  assert known.MPNN_20.symbols == C.PROTEINMPNN_RESTYPES
 
 
 def test_the_two_orderings_in_this_module_are_actually_different() -> None:
@@ -48,7 +48,7 @@ def test_the_two_orderings_in_this_module_are_actually_different() -> None:
 
   Only A, S and T survive the permutation between them.
   """
-  assert C.PROTEINMPNN_RESTYPES != "".join(C.restypes)
+  assert "".join(C.restypes) != C.PROTEINMPNN_RESTYPES
   fixed = [a for a, b in zip(C.PROTEINMPNN_RESTYPES, C.restypes, strict=True) if a == b]
   assert fixed == ["A", "S", "T"]
 
@@ -89,14 +89,15 @@ def test_stop_and_unknown_are_conflated_here_and_the_declaration_says_so() -> No
 
 def test_esm_vocabulary_ordering_matches_the_declaration() -> None:
   """ESM's 20 canonical residues are contiguous at offset 4, in a third distinct ordering."""
-  residues = [c for c in C.ESM_SEQUENCE_VOCAB if len(c) == 1 and c.isalpha() and c.isupper()]
-  esm_20 = "".join(residues[: known.ESM_C.n_symbols])
+  esm_20 = "".join(
+    C.ESM_SEQUENCE_VOCAB[known.ESM_C.offset : known.ESM_C.offset + known.ESM_C.n_symbols],
+  )
   assert esm_20 == known.ESM_C.symbols
   assert C.ESM_SEQUENCE_VOCAB.index("L") == known.ESM_C.offset
   assert C.ESM_AA_CHAR_TO_INT_MAP["-"] == known.ESM_C.specials[SpecialKind.GAP]
-  assert C.ESM_MASK_ID == known.ESM_C.specials[SpecialKind.MASK]
-  assert C.ESM_BOS_ID == known.ESM_C.specials[SpecialKind.BOS]
-  assert C.ESM_EOS_ID == known.ESM_C.specials[SpecialKind.EOS]
+  assert known.ESM_C.specials[SpecialKind.MASK] == C.ESM_MASK_ID
+  assert known.ESM_C.specials[SpecialKind.BOS] == C.ESM_BOS_ID
+  assert known.ESM_C.specials[SpecialKind.EOS] == C.ESM_EOS_ID
 
 
 def test_nucleotide_alphabet_matches_the_declaration() -> None:

--- a/tests/test_alphabet_conformance.py
+++ b/tests/test_alphabet_conformance.py
@@ -1,0 +1,122 @@
+"""Conformance: this repo's alphabet constants match the ecosystem's declarations.
+
+WHY THIS EXISTS
+
+A silent data-corruption bug shipped from this file's constants: the ESM token table was built
+from the AlphaFold residue ordering while carrying a ProteinMPNN name, so every caller honouring
+the documented contract had its residues permuted (only A, S and T are fixed points of that
+permutation). It was shape-valid, so nothing raised.
+
+An ecosystem census found the same two base orderings declared under five different names across
+four repos. The library `alphex` holds one declaration of each. This test asserts that
+*this repo's* constants still agree with those declarations, so that if either side drifts, a
+test fails instead of a number quietly changing.
+
+This is Phase 0 of the migration (decision D4): a **dev-dependency-only** conformance check.
+Nothing under `src/` imports the library, so no runtime dependency edge is created and the
+ecosystem partition is unaffected.
+
+If a test here fails, do NOT edit it to match. One of the two sides is wrong, and which one is
+wrong is the finding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proteinsmc.utils import constants as C  # noqa: N812
+
+alphex = pytest.importorskip(
+  "alphex",
+  reason="alphabet conformance library not installed; add it to the dev group",
+)
+known = alphex.known
+SpecialKind = alphex.SpecialKind
+
+
+def test_restypes_is_the_alphafold_ordering() -> None:
+  """`restypes` is AlphaFold-ordered, despite living next to ProteinMPNN-named constants."""
+  assert "".join(C.restypes) == known.AF_20.symbols
+
+
+def test_proteinmpnn_restypes_is_the_proteinmpnn_ordering() -> None:
+  assert C.PROTEINMPNN_RESTYPES == known.MPNN_20.symbols
+
+
+def test_the_two_orderings_in_this_module_are_actually_different() -> None:
+  """The premise of the whole bug: these look interchangeable and are not.
+
+  Only A, S and T survive the permutation between them.
+  """
+  assert C.PROTEINMPNN_RESTYPES != "".join(C.restypes)
+  fixed = [a for a, b in zip(C.PROTEINMPNN_RESTYPES, C.restypes, strict=True) if a == b]
+  assert fixed == ["A", "S", "T"]
+
+
+def test_aa_char_to_int_map_indexes_the_alphafold_ordering() -> None:
+  """`AA_CHAR_TO_INT_MAP` is built from `restypes`, so its index space is AlphaFold's.
+
+  This is the fact that architecture review finding #1 got wrong: the sentinel constant is
+  named `PROTEINMPNN_X_INT`, but the space it inhabits is AlphaFold-ordered.
+  """
+  for symbol, index in C.AA_CHAR_TO_INT_MAP.items():
+    assert known.AF_20.index_of(symbol) == index
+
+
+def test_sentinel_indices_match_the_declared_22_wide_spaces() -> None:
+  """Both 22-wide declarations put gap at 20 and stop/unknown at 21."""
+  assert C.PROTEINMPNN_X_INT == 21
+  for alphabet in (known.MPNN_GAP_X_STOP_22, known.AF_GAP_X_STOP_22):
+    assert alphabet.specials[SpecialKind.UNKNOWN] == C.UNKNOWN_AA_INT
+    assert alphabet.specials[SpecialKind.STOP] == C.STOP_INT
+    assert alphabet.size == C.PROTEINMPNN_X_INT + 1
+
+
+def test_stop_and_unknown_are_conflated_here_and_the_declaration_says_so() -> None:
+  """A known defect, declared rather than hidden.
+
+  `STOP_INT == UNKNOWN_AA_INT == 21` means a stop codon and an unknown residue are
+  indistinguishable at runtime. The declaration reports it via `conflated_specials` and lints
+  dirty, which is strictly more visibility than three consecutive assignments provide.
+  """
+  assert C.STOP_INT == C.UNKNOWN_AA_INT
+  declaration = known.AF_GAP_X_STOP_22
+  assert declaration.conflated_specials == frozenset(
+    {frozenset({SpecialKind.UNKNOWN, SpecialKind.STOP})},
+  )
+  assert declaration.lint()
+
+
+def test_esm_vocabulary_ordering_matches_the_declaration() -> None:
+  """ESM's 20 canonical residues are contiguous at offset 4, in a third distinct ordering."""
+  residues = [c for c in C.ESM_SEQUENCE_VOCAB if len(c) == 1 and c.isalpha() and c.isupper()]
+  esm_20 = "".join(residues[: known.ESM_C.n_symbols])
+  assert esm_20 == known.ESM_C.symbols
+  assert C.ESM_SEQUENCE_VOCAB.index("L") == known.ESM_C.offset
+  assert C.ESM_AA_CHAR_TO_INT_MAP["-"] == known.ESM_C.specials[SpecialKind.GAP]
+  assert C.ESM_MASK_ID == known.ESM_C.specials[SpecialKind.MASK]
+  assert C.ESM_BOS_ID == known.ESM_C.specials[SpecialKind.BOS]
+  assert C.ESM_EOS_ID == known.ESM_C.specials[SpecialKind.EOS]
+
+
+def test_nucleotide_alphabet_matches_the_declaration() -> None:
+  assert "".join(C.NUCLEOTIDES_CHAR) == known.DNA_4.symbols
+
+
+def test_the_two_esm_token_maps_disagree_exactly_where_the_orderings_do() -> None:
+  """The fix that closed the original bug, pinned.
+
+  Two maps now exist, one per source ordering. They must differ at every index where the two
+  orderings differ, and agree nowhere else -- if they ever became equal, the disambiguation
+  would have been silently undone.
+  """
+  mpnn_map = C.PROTEINMPNN_TO_ESM_AA_MAP_JAX
+  af_map = C.ALPHAFOLD_TO_ESM_AA_MAP_JAX
+  differ = [i for i in range(known.MPNN_20.n_symbols) if int(mpnn_map[i]) != int(af_map[i])]
+  expected = [
+    i
+    for i in range(known.MPNN_20.n_symbols)
+    if known.MPNN_20.symbols[i] != known.AF_20.symbols[i]
+  ]
+  assert differ == expected
+  assert len(differ) == 17

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -1,6 +1,37 @@
 import jax.numpy as jnp
 import pytest
+
 from proteinsmc.utils import constants
+from proteinsmc.utils.constants import (
+    ALPHAFOLD_TO_ESM_AA_MAP_JAX,
+    ESM_SEQUENCE_VOCAB,
+    ESM_UNK_ID,
+    PROTEINMPNN_RESTYPES,
+    PROTEINMPNN_TO_ESM_AA_MAP_JAX,
+    restypes,
+)
+
+
+def test_proteinmpnn_to_esm_map_matches_literal_derivation():
+    """Before/after parity anchor for the alphex-based `_build_esm_token_map` (Step 3).
+
+    Run against BOTH the pre-alphex per-character-lookup implementation and the
+    alphex-`perm()`-based replacement; must pass bit-for-bit against both.
+    """
+    expected = [ESM_SEQUENCE_VOCAB.index(c) for c in PROTEINMPNN_RESTYPES]
+    actual = [int(PROTEINMPNN_TO_ESM_AA_MAP_JAX[i]) for i in range(20)]
+    assert actual == expected
+    assert int(PROTEINMPNN_TO_ESM_AA_MAP_JAX[20]) == ESM_UNK_ID
+    assert int(PROTEINMPNN_TO_ESM_AA_MAP_JAX[21]) == ESM_UNK_ID
+
+
+def test_alphafold_to_esm_map_matches_literal_derivation():
+    """Before/after parity anchor for the alphex-based `_build_esm_token_map` (Step 3)."""
+    expected = [ESM_SEQUENCE_VOCAB.index(c) for c in "".join(restypes)]
+    actual = [int(ALPHAFOLD_TO_ESM_AA_MAP_JAX[i]) for i in range(20)]
+    assert actual == expected
+    assert int(ALPHAFOLD_TO_ESM_AA_MAP_JAX[20]) == ESM_UNK_ID
+    assert int(ALPHAFOLD_TO_ESM_AA_MAP_JAX[21]) == ESM_UNK_ID
 
 
 def test_codon_int_to_res_int_jax_shape_and_dtype():
@@ -42,7 +73,7 @@ def test_codon_int_to_res_int_jax_values():
 
 
 @pytest.mark.skip(reason="Snapshot testing requires syrupy package - not a critical test")
-def test_codon_int_to_res_int_jax_snapshot(snapshot):  # noqa: ANN001, ARG001
+def test_codon_int_to_res_int_jax_snapshot(snapshot):  # noqa: ANN001
     """Snapshot test for CODON_INT_TO_RES_INT_JAX."""
     snapshot.assert_match(
         str(constants.CODON_INT_TO_RES_INT_JAX), "codon_int_to_res_int_jax.snap"

--- a/tests/utils/test_esm.py
+++ b/tests/utils/test_esm.py
@@ -1,22 +1,22 @@
 import jax.numpy as jnp
 import numpy as np
-import chex
 
-
-from proteinsmc.utils.esm import remap_sequences
 from proteinsmc.utils.constants import (
-    PROTEINMPNN_TO_ESM_AA_MAP_JAX,
     ESM_BOS_ID,
     ESM_EOS_ID,
+    ESM_SEQUENCE_VOCAB,
+    PROTEINMPNN_RESTYPES,
 )
+from proteinsmc.utils.esm import remap_sequences
+
 
 def test_remap_sequences():
-    """
-    Tests that a sequence is correctly remapped to ESM's vocabulary
+    """Tests that a sequence is correctly remapped to ESM's vocabulary
     and special tokens are added.
     """
-    # A sample sequence using ColabDesign integer representation (0-19 for AAs)
-    colab_design_sequence = jnp.array([0, 4, 3, 2, 1, 19], dtype=jnp.int32) # ARNDCQ
+    # ProteinMPNN-ordered integer IDs (0-19), per `remap_sequences`'s documented contract.
+    # Under PROTEINMPNN_RESTYPES ("ACDEFGHIKLMNPQRSTVWY") these indices decode to "AFEDCY".
+    colab_design_sequence = jnp.array([0, 4, 3, 2, 1, 19], dtype=jnp.int32)  # AFEDCY
     seq_len = len(colab_design_sequence)
 
     ids = remap_sequences(colab_design_sequence)
@@ -28,6 +28,15 @@ def test_remap_sequences():
     assert ids[0] == ESM_BOS_ID, "BOS token is missing or incorrect"
     assert ids[-1] == ESM_EOS_ID, "EOS token is missing or incorrect"
 
-    # 3. Check remapped sequence content
-    expected_esm_ids = PROTEINMPNN_TO_ESM_AA_MAP_JAX[colab_design_sequence]
+    # 3. Check remapped sequence content. "Expected" is derived independently of
+    # PROTEINMPNN_TO_ESM_AA_MAP_JAX (the map under test) by looking up each residue
+    # character's ESM vocab index directly, mirroring
+    # tests/utils/test_constants.py::test_proteinmpnn_to_esm_map_matches_literal_derivation.
+    # This is the assertion that would actually catch an alias-collision/permutation bug in
+    # the map -- indexing through the map itself, as the previous version of this test did,
+    # is tautologically true regardless of whether the map is correct.
+    expected_esm_ids = [
+        ESM_SEQUENCE_VOCAB.index(PROTEINMPNN_RESTYPES[i])
+        for i in colab_design_sequence.tolist()
+    ]
     np.testing.assert_array_equal(np.asarray(ids[1:-1]), np.asarray(expected_esm_ids))

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,18 @@ wheels = [
 ]
 
 [[package]]
+name = "alphex"
+version = "0.1.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/2f/9b031d6422f3495d765490de930f873e8a17e6f1fa3d3b51085cf90f3e77/alphex-0.1.0a1.tar.gz", hash = "sha256:8ae8706c26eac2ccf78d1dd1e73a41bd3046e87552cc37306f80e43b75954652", size = 22775, upload-time = "2026-08-15T19:14:07.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/59/fe50bd7c21ae9aa57a7b010916510aef70b95e99e2d65d8d11da74c0996c/alphex-0.1.0a1-py3-none-any.whl", hash = "sha256:ce16ce1b214e84d0abc5cf7b68fb8d8d3cc56b056756ee22b36be8e0c94f9338", size = 26720, upload-time = "2026-08-15T19:14:06.587Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1659,6 +1671,7 @@ name = "proteinsmc"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alphex" },
     { name = "array-record" },
     { name = "blackjax" },
     { name = "chex" },
@@ -1706,6 +1719,7 @@ tpu = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alphex", specifier = ">=0.1.0a1" },
     { name = "array-record", specifier = ">=0.8.1" },
     { name = "blackjax" },
     { name = "chex" },

--- a/uv.lock
+++ b/uv.lock
@@ -130,58 +130,6 @@ wheels = [
 ]
 
 [[package]]
-name = "biotite"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "biotraj" },
-    { name = "msgpack" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/64/3526f99fe09add35decea977bd3049672fc0be689d7e0557b0564a55600e/biotite-1.4.0.tar.gz", hash = "sha256:0428427fff47e046a36ecdda1cbb38fc61e652e8df4339bf0a0b7a248a051a8b", size = 37035933, upload-time = "2025-07-07T12:08:53.956Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/9b/b1015d8a6c4fe2c13dd586f7b692264a902cbe53b61cb53a44802e94c851/biotite-1.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d937447eec6247b439d887a79e0dd94e5156a037fa5b399520ac8bee8b078103", size = 40205001, upload-time = "2025-07-07T12:08:15.177Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/a8/8395bbe28f3286df2386ce0830bb168c9f7b0c4f6c6b3f994fd117485819/biotite-1.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a97562fd0341591f6eba58c001cec86cc6de2a45aa1e8d4349b4ff7d7b2cbe3a", size = 39991959, upload-time = "2025-07-07T12:08:18.461Z" },
-    { url = "https://files.pythonhosted.org/packages/07/91/5ac386b325dc638eec21a68ef76a7ed6bb3a1fde0dbf8c7783a9545b7f21/biotite-1.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0813b424796dcc11bd2093a5e976c034c7190f3b2bedc503fb556119375977b1", size = 54434605, upload-time = "2025-07-07T12:08:22.278Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5d/34df5d5acb35f8d4b6bb8df4f73f50ec2a9aa2e419cdb5ab3e5c24012cd7/biotite-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cae4560fefd5583976d6434f647b73fe302864a1a7891e35cad4477309f58cce", size = 39884893, upload-time = "2025-07-07T12:08:25.461Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/a5/67c8808fe0935cfdf0f8bd993735595ed5110a6dbee98f84581b81066258/biotite-1.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:145f229f4262ab352eb5869f2ea56a5823911267abe7edca50ec6e5c90837097", size = 40144461, upload-time = "2025-07-07T12:08:28.358Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e0/64716fb2ce9d7749bb41cc932c667b0f6d478e09367b36d273b1f77b06f3/biotite-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:19b4cfbdbe1ad94319dfea61d3dcdb07d476ba5bf55fb507021d6a5a5d4762d8", size = 39924549, upload-time = "2025-07-07T12:08:31.139Z" },
-    { url = "https://files.pythonhosted.org/packages/77/e4/eb18efca3bf159164144238ebfde8c064cfb122194183507b5dfcd690969/biotite-1.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d17dbcabf8dfce25fff50f2c31e03392f8bd66dce064379e5f4c03d28ad66fc6", size = 56284190, upload-time = "2025-07-07T12:08:34.406Z" },
-    { url = "https://files.pythonhosted.org/packages/66/3e/c1f1ea1c4c407b24c1dd9a92b02c6babaa1800152693ae662c471daf6f95/biotite-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:3dcb2c88f5dcfce6fee94800be1a42aca82c468baea13f04701ebefd711d9438", size = 39803852, upload-time = "2025-07-07T12:08:37.68Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/38/7b6f69b3b5e6e3dbc0aabdd76c6f071a9e763d606f7b9a489cb95b92a000/biotite-1.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2b85d704c7f24bd03a2023d122776443588c97cfcc2875eed9acb4e29ce36a5", size = 40130802, upload-time = "2025-07-07T12:08:40.942Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/5d/087d2bd4db67bebdc6d7500be671cf8dd7471d6b887456ecd5c47561986f/biotite-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e681619cc9712cee436950a66965791fd40548d0369ddc8dba2c52a4f1d26a95", size = 39912406, upload-time = "2025-07-07T12:08:43.839Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/2e/aea1d77a3197d8f7caac0ffb19a6abdb3138ba69d90c8f74ef5a996d13a8/biotite-1.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96644d9bcf8b14f3ce7758c855f3773ddd5d95c06cba178847911d871b81b7d2", size = 56171242, upload-time = "2025-07-07T12:08:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/b6/f81ab2e7b0ef3bb3dccd147cff8458e16ec36bf7b08901772075e872ce66/biotite-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:c9c214f56a4868f840dcbbac9ad75f507b9a87c978c68c321dda745cffecba4c", size = 39807120, upload-time = "2025-07-07T12:08:50.633Z" },
-]
-
-[[package]]
-name = "biotraj"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "scipy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/21/2287edfd0d2569639eea706e25c39e63b46a384cf1712db8ea05768317b0/biotraj-1.2.2.tar.gz", hash = "sha256:4bcba92101ed50f369cc1487fb5dfcfe1d8402ad47adaa9232b080553271663a", size = 3909030, upload-time = "2024-11-02T11:30:54.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/dd/4e257a394e4a686a5973d6238bc5fb6fa321423c9401e278a34c51a01425/biotraj-1.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8dc790c95f90760d08986c896783f3531cfd5feb3bd8496f07949ccccd8eafb3", size = 863170, upload-time = "2024-11-02T11:30:34.007Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/3e/90d2c50912df949c5731c564f5c7bf853378d7f2d31f276dd31eb42fb663/biotraj-1.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:39d1ce8d7c7e55c87bf35248c20f4d7ed09349b99ee090e61068c9c08d32b179", size = 835504, upload-time = "2024-11-02T11:30:35.878Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/86/d24589c5f8f6ef4685e6a8c8a670a9be17657677f793b48e19520ed08209/biotraj-1.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0accd626b3cb6b29fb4491d593c41daa694edddde8e8dc113228b1969a30c9f6", size = 2246778, upload-time = "2024-11-02T11:30:37.642Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/78/3cd3ca90490ff5730fffed57464c104a146a0c35280fc4bea2bfafb72b48/biotraj-1.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8fb09bf6f7cd44c9356880166e45fe1606b05113b4642b99f8b85c25f51699ba", size = 366212, upload-time = "2024-11-02T11:30:39.427Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/da/bf56c6cc27212ed2b5ad3beb1c399b74ac147236b22900a9434760ebfa27/biotraj-1.2.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b584c2da6d353c09f839e9b72fa243b6f45050b311cdcd5a0f3a44ced80d714e", size = 859982, upload-time = "2024-11-02T11:30:40.948Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/d2/369ed44ad23f8c0464f7b80d41143d717896097b39fe3dd3e07e6d162fef/biotraj-1.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7bab65f5e3975a844c1018ea5873acd7dd21a64e8ebf0c145635c1d2fb9ef9bd", size = 833765, upload-time = "2024-11-02T11:30:42.628Z" },
-    { url = "https://files.pythonhosted.org/packages/80/cd/c607b6337ddcf55cc0249527819b727ef28481d7c56ace54cca69400c2b9/biotraj-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b449930fa70666db0f2e7b1e5f5dad65917086adc66a70f26db38d79b0171815", size = 2239973, upload-time = "2024-11-02T11:30:44.61Z" },
-    { url = "https://files.pythonhosted.org/packages/13/56/bed88eb34acb31855e7c82a1d68e58775c037ec66ccb2bb02ff310615240/biotraj-1.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:3427567cc0bd0e981bf7de1a6b65baf82984171852994d304b2f316a8926db83", size = 358790, upload-time = "2024-11-02T11:30:46.19Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/12/8f6a2b21a8b43a2bf85352c993afecb21d40eb3d7373b6242163a93f57e0/biotraj-1.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31ed2a9e8a6436f5432f22883e68a36c223b98de0ab80225efbaf67da339a2b2", size = 856347, upload-time = "2024-11-02T11:30:47.431Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/4d/b1e792c01e61bbfe03b290a0805f0c7bc3949bf9cd4031bcdd183d2f2524/biotraj-1.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6a8c84ac95bf65b73928774ec46b72d62b0f30fa12eb8c56c78ed25235f0acf8", size = 832499, upload-time = "2024-11-02T11:30:49.363Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6f/ab71525583a7824c70f71de387a1c5ceb27ddcb3fda2dacb734e5b875f14/biotraj-1.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dcfa4a4c755ddc206f81999fd47664747cd2e546e16a51d885332cd4c955f41", size = 2246545, upload-time = "2024-11-02T11:30:50.829Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/9a/46d2d67b5b672d5d2ffbfb3551fc4b499b45d5edce2558e259f69b72a0d9/biotraj-1.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:e0ed1b586e23ad53e53fb42be8541fb964ec6c4183e6d500fef0bcc1bdcd7487", size = 359596, upload-time = "2024-11-02T11:30:52.876Z" },
-]
-
-[[package]]
 name = "blackjax"
 version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -360,15 +308,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpickle"
-version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz", hash = "sha256:b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64", size = 22113, upload-time = "2025-01-14T17:02:05.085Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl", hash = "sha256:c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e", size = 20992, upload-time = "2025-01-14T17:02:02.417Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -522,35 +461,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dm-tree"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "attrs" },
-    { name = "numpy" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/83/ce29720ccf934c6cfa9b9c95ebbe96558386e66886626066632b5e44afed/dm_tree-0.1.9.tar.gz", hash = "sha256:a4c7db3d3935a5a2d5e4b383fc26c6b0cd6f78c6d4605d3e7b518800ecd5342b", size = 35623, upload-time = "2025-01-30T20:45:37.13Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/b6/2d2de9f8901ccc5b6f34aea678e732816853015b9d756c86efcec189bf4b/dm_tree-0.1.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7d7d784afaeb4b67d87d858261aaf02503939ddc1f09c4cca70728f9892ab004", size = 173561, upload-time = "2025-03-31T08:35:40.042Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/07/57459f32cf5683c25b596ab58f42a3305f91876c2f03d2fa6e9d0df75fcb/dm_tree-0.1.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e660d1779ddcbd1348410d08f67db4870d413a3ec4ba8b4b045bd5ce4bd8f35c", size = 146926, upload-time = "2025-01-30T20:45:20.622Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/939fbf81177c7cb3b1e5ddebd696237b3be9520769cce882f064de497103/dm_tree-0.1.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294dc1cecf87552a45cdd5ddb215e7f5295a5a47c46f1f0a0463c3dd02a527d7", size = 152851, upload-time = "2025-01-30T20:45:23.032Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3e/a46933e0157b0ac87619a754ce1a796b2afc6386fca7c11f95c010f40745/dm_tree-0.1.9-cp311-cp311-win_amd64.whl", hash = "sha256:12f4cc6cd52a39aa38ff31577b6d79b6136a9a89273a876bf62335c9f65c27bf", size = 101522, upload-time = "2025-01-30T20:45:24.433Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/02/61aa90ab695918b4389d75c99bf0ec3cd0abacf1cadbef4053626f23ce34/dm_tree-0.1.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a8d20eeab7fde77a3ed71f07716021eb0edfb4812a128eb381d108af3a310257", size = 175012, upload-time = "2025-03-31T08:35:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/81/10/120cd40556407879c1069941bd8b0d1a75754128c1a5bf0e27dbcf2a49fc/dm_tree-0.1.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80c43417814b1181d3367b335460bfdd30b79ee187a64220e11f6ddd093a4b15", size = 147204, upload-time = "2025-01-30T20:45:25.541Z" },
-    { url = "https://files.pythonhosted.org/packages/86/52/27607a275c12858b979b8e943d2bd3bd0f9028503bb7079d5830a8b3cac0/dm_tree-0.1.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2334cfe9d2ed4293f9f1c7aefba0657deaab9ea74b5fadd966f6d01d9b6b42d9", size = 153013, upload-time = "2025-01-30T20:45:26.886Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/97/4f78412f73a9350bc8f934441bae5b68b102c8f4240a7f06b4114b51d6de/dm_tree-0.1.9-cp312-cp312-win_amd64.whl", hash = "sha256:9020a5ce256fcc83aa4bc190cc96dd66e87685db0a6e501b0c06aa492c2e38fc", size = 102022, upload-time = "2025-01-30T20:45:28.701Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/13/823788cd0f7964cadcfa56d1e0f9e5e987ee73b5db6273bc00168f524f1a/dm_tree-0.1.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cfa33c2e028155810ad1b4e11928707bf47489516763a86e79cab2954d23bf68", size = 175000, upload-time = "2025-03-31T08:35:42.483Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6a/512abdf7f20acc6cd6fce77f7663014d129aa313b5953aa2603d58fdb0c9/dm_tree-0.1.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d05622d074353cf434049206e53c12147903a048c4bd7d77f2800d427413ad78", size = 147210, upload-time = "2025-01-30T20:45:29.732Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0a/f4d72ffb64ab3edc1fa66261f81ee3b4142ab14cd8aa1dfc7bbeca5ee4ba/dm_tree-0.1.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f68b0efad76703dd4648586c75618a48cdd671b68c3266fe980e323c15423607", size = 153043, upload-time = "2025-01-30T20:45:30.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ee/529ce999770b4d621a64af86c60cfee52f0cdd7294752105179ebf1c07c6/dm_tree-0.1.9-cp313-cp313-win_amd64.whl", hash = "sha256:e97c34fcb44941c36b7ee81dcdbceba0fbe728bddcc77e5837ab2eb665bcbff8", size = 102043, upload-time = "2025-01-30T20:45:32.004Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/3c/5b40f8862390e9172e776cf610f3791c1af01f140a5698799fbe4a97206f/dm_tree-0.1.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b06e7a5da1c31a82521a60060573527e8d24b9920fdd20b2ec86f08412737598", size = 180821, upload-time = "2025-03-31T08:35:44.474Z" },
-    { url = "https://files.pythonhosted.org/packages/84/1d/3cdbeeb3f6937a47a26cee502bffeccc2e55b97dfcce8a1d1135ea1b5b47/dm_tree-0.1.9-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6893fcdc5cf1a4f459cfc383526d35d42e7c671ae565d7e429a2f2cb2cb93e89", size = 147282, upload-time = "2025-01-30T20:45:33.896Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/37/15603079854394f16e3833a7b50696c1f3cbf30a2243a119f64f18a16f36/dm_tree-0.1.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1f5d1e96b3a7de22b25b13a5eb30f41f8cf9c02dd4479a24920de99e780903c", size = 153052, upload-time = "2025-01-30T20:45:35.907Z" },
-]
-
-[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -661,89 +571,12 @@ wheels = [
 ]
 
 [[package]]
-name = "foldcomp"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/c7/28076cb36546f15fa049e08e33ca04d72399ddea487e5b05c38da4216ba2/foldcomp-0.1.0.tar.gz", hash = "sha256:0ca2ddb6243bf7c89640aea1db502e0868b3dffb562b0c847bae3354d92cab76", size = 21296, upload-time = "2025-07-30T07:27:37.042Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/eb/620d837ace173f3ceb1955a0c8b13e229614d7f154d89f2277be0adba5e6/foldcomp-0.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:352985c26af41c9d8365568da86faefba4acc18d84fd54e1cb9ca385f8496cdd", size = 399431, upload-time = "2025-07-30T07:27:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d0/d84890674aa0b02609344b588a2ae08b1de1ebc775c513141f805d18ed1a/foldcomp-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8de8398914c41ae83ca2bb23d4f170e26bac68dea155eee983add5182e8aa1", size = 203193, upload-time = "2025-07-30T07:27:02.327Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2f/933f96e392ec14954bde2f096684724627bc76f19b32bda444183dc3d889/foldcomp-0.1.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74f4667de5edbe6d163dcaacd9dff065233e9373e744327a38d59bbdc35c8f8f", size = 261143, upload-time = "2025-07-30T07:27:03.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/12/99e5f2be931edfc9d1a4f38b9c070e325b4b26973ac4499166801b57d811/foldcomp-0.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:600ed4b2dbee9bafbb2da3a1841721c51920fcfcb40ce85192716bb02b0e15b0", size = 1297536, upload-time = "2025-07-30T07:27:04.615Z" },
-    { url = "https://files.pythonhosted.org/packages/84/dc/77bb7d16edbf9dedd416822b8f8f82bafcc57e9de9ce4377dff9955615d4/foldcomp-0.1.0-cp311-cp311-win32.whl", hash = "sha256:f0568b2df7abe051a119d9f702d9976ddd42f592cf41fcabe3a2ad20dc00ac43", size = 146497, upload-time = "2025-07-30T07:27:05.825Z" },
-    { url = "https://files.pythonhosted.org/packages/78/36/4e20d86eaefc9ee4a99f289c8dbd4952addffa20099481356d7b535a4f7f/foldcomp-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:72e416db1b7974a906ea22168aad28385f21319354c6f1c5f32f31a70120e199", size = 157356, upload-time = "2025-07-30T07:27:06.602Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/cf/06ef97b35700480267138312f9be357f582805b2c5d91c2941721d4c6bf9/foldcomp-0.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:97343a95183f4f11816e95dbab06e543d117ca9ab5eac8ccd8abb4f71c04e967", size = 398851, upload-time = "2025-07-30T07:27:07.419Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4a/8c711597ac2f01e3298b89a1beb4496a2b0eff15b2a9908f69dc7bf775b4/foldcomp-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:49587e699c4a50c09ef21fe119b8de4c4790f906bc7ded2bef56aa4747f15e54", size = 202905, upload-time = "2025-07-30T07:27:08.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/a1/72fdcba0eb56e1eaebf242d0393dcee40512907e7efb613ea88be5d58394/foldcomp-0.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fcc691176967d970a311150bb7b7658ca552881e4a41b7efe675bdbf8bb2c188", size = 261265, upload-time = "2025-07-30T07:27:09.478Z" },
-    { url = "https://files.pythonhosted.org/packages/48/bc/fe25dbcbd0d2485df4432480569f7d5825daca9004e291c14c859d17642e/foldcomp-0.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:39f8c7fa4f685026e0e21f262183130389437a0d3af14ba3e89b35032a46a317", size = 1297685, upload-time = "2025-07-30T07:27:10.671Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/b6/664f2081db52ac6f65a7c765b92c15fbe747f06bc9ebe54b7bec34d7be58/foldcomp-0.1.0-cp312-cp312-win32.whl", hash = "sha256:53dc081961feb9e03e981e59f0f55e7dd585d54aae4b926d8bd6ddbf5dc0eed8", size = 146629, upload-time = "2025-07-30T07:27:11.699Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/93/e1f47655e992e4b9934a93b9af5284e355efbd294f519900269834488dd2/foldcomp-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:21ff558453b5eb601465718c90350d0d6d1bf87c270d68141274f8b1aa5aa009", size = 157519, upload-time = "2025-07-30T07:27:12.485Z" },
-    { url = "https://files.pythonhosted.org/packages/78/15/54f2f976928679e067f0bfe0f91c437f3ad21ada3046fe8d222931f3e52f/foldcomp-0.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:07b6c5586c2b24b24a6302e7146d3f0f0c7735626f3efed750ced3485159d0dd", size = 398821, upload-time = "2025-07-30T07:27:13.327Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/22/151b195eccaf443be3979a6e34e164b5d3123ddb200efaca40ef0eac1a42/foldcomp-0.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6d044b54a202d5d36b78cd97c4efc351c5912285673abd54461a86fb77d195a", size = 202885, upload-time = "2025-07-30T07:27:14.473Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/2e232841542e484ae0faca0d3e92acea0e2ea8b1d0f06c4a9ba9d7b8c87d/foldcomp-0.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbe6b8ccad3f837d7448d2210d50ccba02ccdf0073e9774e000d582533a3d42a", size = 261268, upload-time = "2025-07-30T07:27:15.291Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/10/93358fa4a3c5d16d491224c4c56e41bb56ae7b2a85abf0d9fc3b42ffb719/foldcomp-0.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0170d65a5f02f93dd02e36a33cbb505587190510228685bdbb1ccffdb6d0cab2", size = 1297710, upload-time = "2025-07-30T07:27:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/23/58/642c8304ff9ead00935b4c486bf20dffc8b3f0c6013a79c73a1420140988/foldcomp-0.1.0-cp313-cp313-win32.whl", hash = "sha256:14c880a088db1e1cc35b1e52a68233913cee8617e1d2f1f5f042e9e9b3b2f92f", size = 146643, upload-time = "2025-07-30T07:27:17.775Z" },
-    { url = "https://files.pythonhosted.org/packages/64/78/cb7bd13cb1f0db353363238f72364e276d92fa42d5a06edc18f614fc22f0/foldcomp-0.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a66bb07dba98bd91c04539d5bc083d2d89aa5a7563c736dd2c0748b2875539cf", size = 157515, upload-time = "2025-07-30T07:27:18.548Z" },
-    { url = "https://files.pythonhosted.org/packages/83/b3/c5801b058f1c6eeed302621c97fb667561e5dabf0903b7334a3b947cc075/foldcomp-0.1.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:20bda6ec40bec9c294065c67625944fb102ae78b3d41a8d614ea53f232b74566", size = 398805, upload-time = "2025-07-30T07:27:19.362Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/ab/bf8ed92211495a235f4deb6cd3641ac84f7145e89d33f83897cf8194c22e/foldcomp-0.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e4264ff3c6301778902541a2fd44ae088b0140ed1d16cdb50c4c9543c2800fb4", size = 202913, upload-time = "2025-07-30T07:27:20.21Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/19/37eb49b8162f246ede2552c267d40d076b60e1d998c5e96ddced9268bce6/foldcomp-0.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ba8934941ec61ca0825f41c6a458ab29146f21c71227d635e8f9e509e449d23", size = 261306, upload-time = "2025-07-30T07:27:21.345Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/98/8af9679b4fbb97ba3aac5a5c78de55c7ad67e885cd0735c3c2e7830add8a/foldcomp-0.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:91e8356e26a9ad0194515c3326b5c14507d665ad0de91b7fe4cd8374325f497d", size = 1297736, upload-time = "2025-07-30T07:27:22.487Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/f8/d815a72bad92402254dd3f18e960d374f272338722506a46f0f07271e440/foldcomp-0.1.0-cp314-cp314-win32.whl", hash = "sha256:78f4dd88486d678939bbc4c0bf04730105f978ffb366d4421d4aa7a2a81bd73e", size = 152263, upload-time = "2025-07-30T07:27:23.394Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/84/9b2f70fca0cc92875ee09bf491258de011fb3a9fa82b8d179467766bcd2c/foldcomp-0.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:c5c036fabb41305c2b082b01920ada8eb9cae1b485969c58a3f8502cc64d1233", size = 160850, upload-time = "2025-07-30T07:27:24.245Z" },
-]
-
-[[package]]
 name = "fsspec"
 version = "2025.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
-]
-
-[[package]]
-name = "gmmx"
-version = "0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jax" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/6b/6023c93fe6b065bc1a397ec891f32557b7cd193dccce8431251188b89ce0/gmmx-0.7.tar.gz", hash = "sha256:4bf8274419cd84727155a043f2bf53307b30aff31c9d4dc51b5b41b65d7bec4d", size = 16841, upload-time = "2025-07-07T18:31:24.96Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/44/5a76e0baefa5dd504ae60f6ec0803625f5c07427b65d4782dec2d294ef9e/gmmx-0.7-py3-none-any.whl", hash = "sha256:222a2947ac3bc2f8139e261919792f642b19e615ee13e512c703fc57ba92ad70", size = 13013, upload-time = "2025-07-07T18:31:24.17Z" },
-]
-
-[[package]]
-name = "grain"
-version = "0.2.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "array-record", marker = "sys_platform != 'win32'" },
-    { name = "cloudpickle" },
-    { name = "dm-tree" },
-    { name = "etils", extra = ["epath", "epy"] },
-    { name = "more-itertools" },
-    { name = "numpy" },
-    { name = "protobuf" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ae/255dbba3e766f514def03fc694eff9d23846e208ce39a1aa1c9b1158bde1/grain-0.2.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fb4a151f7f84e36197beacea27f3c296d46b9e50a25a724999ddf97956b73d2b", size = 420697, upload-time = "2025-08-21T20:17:41.213Z" },
-    { url = "https://files.pythonhosted.org/packages/75/41/3d86c5db2bff0c5c46b65baacf1cc5860044ba33c04104c767e44d9ed969/grain-0.2.12-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ba7010162cd8481e4e7667977cd1c42b5c361d9e61dbcafd264be5b7a3e223c", size = 499419, upload-time = "2025-08-21T20:17:42.339Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7a/6b37c37cb9ea633496fd65844dfbf728d46c97cab664d63811c9c569419c/grain-0.2.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:787de94f9d9764f549af4fa08141fd68cdae5486f989ae11c568c72d088314c7", size = 501523, upload-time = "2025-08-21T20:17:43.786Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/08/02f5a37eaf915c8a3a3fcb88f99dd117d519300a9299aeb81665b5d5a900/grain-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:299827f6bf50adb49309b9dbdb3891844f25d000927274a9ec8d219a4cfdd136", size = 407836, upload-time = "2025-08-21T20:17:45.231Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ae/27910a8724871042f3fcf8013302867d98e775280cbbf54f30801774eed8/grain-0.2.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7cb396ff113f0b54b326c356a02f8eb5f65a4644b9f8bf67fba555117bbd566f", size = 418033, upload-time = "2025-08-21T20:17:46.376Z" },
-    { url = "https://files.pythonhosted.org/packages/47/44/853fc99337dff11fed8aab132e4f8f07c0ed33afd50bcb026c55f52b1cf9/grain-0.2.12-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:072b87ef93603cae1ea44b2029f7979e5b85c6e6fbe31d41ea34a64a67cbc04f", size = 497946, upload-time = "2025-08-21T20:17:47.36Z" },
-    { url = "https://files.pythonhosted.org/packages/26/08/7bf07b0460f30c67d205eb48b903ae0668a5cc34c9c5dda609380e810594/grain-0.2.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7aaddac8a7ac468a536edcbd087bc4466b14a9d2f70c92d9f1f9bf2fb3a1bc9", size = 499428, upload-time = "2025-08-21T20:17:48.672Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f0/471db37d897bf7515ec8ec379a714ea50e9526749c5fa6c68d320101a78e/grain-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:44f493253831e1ee024e2deaa2df22442b45d6e64db6eb321c3d5cc6263be185", size = 407938, upload-time = "2025-08-21T20:17:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/27/35/ac669bbf18a137afc293991377770db0d0dd05b04e810a3957aa1b9f7b63/grain-0.2.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c4f750f79b7aba5a0cca5f360420da5bba7f47173a545a366ae2d9f1c34aab71", size = 418129, upload-time = "2025-08-21T20:17:50.856Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/97/2e1aac75e6d2354b9684526257ace2231a142db6b35310815f92c0e18fde/grain-0.2.12-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b91215b82216a6ee15c4f91335bab7d7f887709a6e9a36c7c6fdf8a65e56ebb5", size = 498086, upload-time = "2025-08-21T20:17:51.88Z" },
-    { url = "https://files.pythonhosted.org/packages/02/3d/fc2dd16c216da51c79c4c0f6a37480326fd613cb977505334109108efd56/grain-0.2.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5fd924868324a4f5e2506a23f4c8890384fa0833ab1e6094973485de62d58dfe", size = 499600, upload-time = "2025-08-21T20:17:53.311Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3a/bb21dbf833eb1ad34dbf70b1e3fd729cf09cbe91926219f4b2d8844d05e9/grain-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:91eec23f29724210d6e1ac9a0cd6cea71292191cf55ba754fe87192ab322f18a", size = 408041, upload-time = "2025-08-21T20:17:54.259Z" },
 ]
 
 [[package]]
@@ -755,36 +588,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
     { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/28a5b2fa42d12b3d7e5614145f0bd89714c34c08be6aabe39c14dd52db34/greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c", size = 1548385, upload-time = "2025-11-04T12:42:11.067Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/05/03f2f0bdd0b0ff9a4f7b99333d57b53a7709c27723ec8123056b084e69cd/greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5", size = 1613329, upload-time = "2025-11-04T12:42:12.928Z" },
     { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -795,32 +632,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "h5py"
-version = "3.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/1b/ad24a8ce846cf0519695c10491e99969d9d203b9632c4fcd5004b1641c2e/h5py-3.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f30dbc58f2a0efeec6c8836c97f6c94afd769023f44e2bb0ed7b17a16ec46088", size = 3352382, upload-time = "2025-06-06T14:04:37.95Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5b/a066e459ca48b47cc73a5c668e9924d9619da9e3c500d9fb9c29c03858ec/h5py-3.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:543877d7f3d8f8a9828ed5df6a0b78ca3d8846244b9702e99ed0d53610b583a8", size = 2852492, upload-time = "2025-06-06T14:04:42.092Z" },
-    { url = "https://files.pythonhosted.org/packages/08/0c/5e6aaf221557314bc15ba0e0da92e40b24af97ab162076c8ae009320a42b/h5py-3.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c497600c0496548810047257e36360ff551df8b59156d3a4181072eed47d8ad", size = 4298002, upload-time = "2025-06-06T14:04:47.106Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d4/d461649cafd5137088fb7f8e78fdc6621bb0c4ff2c090a389f68e8edc136/h5py-3.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:723a40ee6505bd354bfd26385f2dae7bbfa87655f4e61bab175a49d72ebfc06b", size = 4516618, upload-time = "2025-06-06T14:04:52.467Z" },
-    { url = "https://files.pythonhosted.org/packages/db/0c/6c3f879a0f8e891625817637fad902da6e764e36919ed091dc77529004ac/h5py-3.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:d2744b520440a996f2dae97f901caa8a953afc055db4673a993f2d87d7f38713", size = 2874888, upload-time = "2025-06-06T14:04:56.95Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/77/8f651053c1843391e38a189ccf50df7e261ef8cd8bfd8baba0cbe694f7c3/h5py-3.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e0045115d83272090b0717c555a31398c2c089b87d212ceba800d3dc5d952e23", size = 3312740, upload-time = "2025-06-06T14:05:01.193Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/10/20436a6cf419b31124e59fefc78d74cb061ccb22213226a583928a65d715/h5py-3.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6da62509b7e1d71a7d110478aa25d245dd32c8d9a1daee9d2a42dba8717b047a", size = 2829207, upload-time = "2025-06-06T14:05:05.061Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/c8bfe8543bfdd7ccfafd46d8cfd96fce53d6c33e9c7921f375530ee1d39a/h5py-3.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:554ef0ced3571366d4d383427c00c966c360e178b5fb5ee5bb31a435c424db0c", size = 4708455, upload-time = "2025-06-06T14:05:11.528Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f9/f00de11c82c88bfc1ef22633557bfba9e271e0cb3189ad704183fc4a2644/h5py-3.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cbd41f4e3761f150aa5b662df991868ca533872c95467216f2bec5fcad84882", size = 4929422, upload-time = "2025-06-06T14:05:18.399Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/6d/6426d5d456f593c94b96fa942a9b3988ce4d65ebaf57d7273e452a7222e8/h5py-3.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:bf4897d67e613ecf5bdfbdab39a1158a64df105827da70ea1d90243d796d367f", size = 2862845, upload-time = "2025-06-06T14:05:23.699Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c2/7efe82d09ca10afd77cd7c286e42342d520c049a8c43650194928bcc635c/h5py-3.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:aa4b7bbce683379b7bf80aaba68e17e23396100336a8d500206520052be2f812", size = 3289245, upload-time = "2025-06-06T14:05:28.24Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/31/f570fab1239b0d9441024b92b6ad03bb414ffa69101a985e4c83d37608bd/h5py-3.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ef9603a501a04fcd0ba28dd8f0995303d26a77a980a1f9474b3417543d4c6174", size = 2807335, upload-time = "2025-06-06T14:05:31.997Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ce/3a21d87896bc7e3e9255e0ad5583ae31ae9e6b4b00e0bcb2a67e2b6acdbc/h5py-3.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8cbaf6910fa3983c46172666b0b8da7b7bd90d764399ca983236f2400436eeb", size = 4700675, upload-time = "2025-06-06T14:05:37.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d90e6445ab7c146d7f7981b11895d70bc1dd91278a4f9f9028bc0c95e4a53f13", size = 4921632, upload-time = "2025-06-06T14:05:43.464Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/6d/0084ed0b78d4fd3e7530c32491f2884140d9b06365dac8a08de726421d4a/h5py-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae18e3de237a7a830adb76aaa68ad438d85fe6e19e0d99944a3ce46b772c69b3", size = 2852929, upload-time = "2025-06-06T14:05:47.659Z" },
 ]
 
 [[package]]
@@ -836,34 +647,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/25/3e32ab61cc7145b11eee9d745988e2f0f4fafda81b25980eebf97d8cff15/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0a0005fd08f002180f7a12d4e13b22be277725bc23ed0529f8add5c7a6309c06", size = 3248612, upload-time = "2025-09-12T20:10:24.093Z" },
     { url = "https://files.pythonhosted.org/packages/2c/3d/ab7109e607ed321afaa690f557a9ada6d6d164ec852fd6bf9979665dc3d6/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f900481cf6e362a6c549c61ff77468bd59d6dd082f3170a36acfef2eb6a6793f", size = 3353360, upload-time = "2025-09-12T20:10:25.563Z" },
     { url = "https://files.pythonhosted.org/packages/ee/0e/471f0a21db36e71a2f1752767ad77e92d8cde24e974e03d662931b1305ec/hf_xet-1.1.10-cp37-abi3-win_amd64.whl", hash = "sha256:5f54b19cc347c13235ae7ee98b330c26dd65ef1df47e5316ffb1e87713ca7045", size = 2804691, upload-time = "2025-09-12T20:10:28.433Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1029,6 +812,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/e6/5fd0f6fff79eb47469ff9c4fa27125b661517a2fbf8884689b02e9fdfaa8/jax-0.7.2-py3-none-any.whl", hash = "sha256:e7e32f9be51ae5cc6854225958c57de8cca2187d279844338465b15e8a1fe7f2", size = 2835570, upload-time = "2025-09-16T16:48:51.33Z" },
 ]
 
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib" },
+]
+tpu = [
+    { name = "jaxlib" },
+    { name = "libtpu" },
+    { name = "requests" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a3/f5e6cdfb3fe3ff0285becf08edb84345bd71913102c77ccf9fe71816e7c7/jax_cuda12_pjrt-0.7.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d87d666d0c523fadaadb7194e7c274dcc5a0e7f8f8d1d7e2835353ef32bef01c", size = 125832574, upload-time = "2025-09-16T16:50:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/64/b8653c36cb1075b34d9661a354d3b4c2db9e01a34cecbae3c5b4c2d1caf8/jax_cuda12_pjrt-0.7.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:3977726a2a332b0bd34831bdeb2b5653363442f3012c2996fc88080aaf6b3bad", size = 132725132, upload-time = "2025-09-16T16:50:27.521Z" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda12-pjrt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/1a/a6e94d7c8cc8fc67ed3f51245dfc7844a4dced7a2e974d40bdcdb7964be8/jax_cuda12_plugin-0.7.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:2a727a89ae69ac21c1f5093d8d5aef89a0e692e66b034fc934c8accc72e40290", size = 5466351, upload-time = "2025-09-16T17:01:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/56708eff0065bf68cc5c738f5bdfbec4bd76ceddbef3bfaf9ac869bcbd2f/jax_cuda12_plugin-0.7.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:adc924ebc7a45c8d3400ea0118dc70a7082b2a86e35711738d403dd3815d09bf", size = 5479806, upload-time = "2025-09-16T17:01:49.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dd/105045cb14d993b00a0ec61458f2e559d0f410955aeb8e79b1bab80fc394/jax_cuda12_plugin-0.7.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:98a975655382858d874d6471ce97194310609d0a2a7c4283c6e07e37933b7768", size = 5460119, upload-time = "2025-09-16T17:01:51.325Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c7/9698f667e309ac4bf29889190f5344891eb59479002a6a3ad253bc0a1d91/jax_cuda12_plugin-0.7.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:8284e7cf7f544906604f111702a6f0011a96df7f0113878b381bec0905172536", size = 5476864, upload-time = "2025-09-16T17:01:52.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/e7deb16fba9829eb8391407b8057a0a2b4fb781035f267b2369043921fae/jax_cuda12_plugin-0.7.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:5e3e2aa4d721fb02dd1028262aaeaec2958e45bca5c4d3512b29151b570cb425", size = 5460772, upload-time = "2025-09-16T17:01:54.035Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ce/970889a70a03978dc28dc6e895e054995760dd141cbe08a5229544adb21f/jax_cuda12_plugin-0.7.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:7212c12d75b7dc51275f271827df4a6d378430c06f650e6c31c162fe9579ff12", size = 5476949, upload-time = "2025-09-16T17:01:55.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e9/28464bb15c442085333faebf0a41370428cb2d947ad3ee631296e889e736/jax_cuda12_plugin-0.7.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:45d5a1cbf0b9d05318722382fc71c4cede0c028bad6aa8e53f7a7032392f719c", size = 5474728, upload-time = "2025-09-16T17:01:56.885Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a4/ff0024fa1b9de7c666d218871f9408beb47fe1a036132bbd0e281375706a/jax_cuda12_plugin-0.7.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:05b6942985f015be82becd2cec363f0aceb25311981821d7613a51f630490e8c", size = 5485236, upload-time = "2025-09-16T17:01:58.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d0/a65d3e0375c7dc8425ef49671090f6eae23a0a8c780bd80127a4a0c25ced/jax_cuda12_plugin-0.7.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:e881b56fe27e6870db2f2e9c574b81965fe1102b1532eae60e240a40c065daf5", size = 5461974, upload-time = "2025-09-16T17:02:00.017Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5c/5900fe909801469de67df6d7e99dbff93efdb9ab31219c81f124eae1f882/jax_cuda12_plugin-0.7.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:23b8f1050c48b4020610fb818930d3cbe0304c6681b069687e5416ee349bd734", size = 5477722, upload-time = "2025-09-16T17:02:01.258Z" },
+    { url = "https://files.pythonhosted.org/packages/68/38/da12a17f1f26e3d36670b2c290fcf826c55cd267f6da49aef27ed24a0401/jax_cuda12_plugin-0.7.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:7ad3afc51bcbc4e8117845d359e5d02cbc5ca2b152efdebd3c55fb9e4c2f848e", size = 5475355, upload-time = "2025-09-16T17:02:02.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d1/07bf754ed5cd43e706f6d64c681e8b0de43b3235cfa2d9507f2ceb9f3bd2/jax_cuda12_plugin-0.7.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:1d00f9f5c5f68ae0f41cb7b589005ed5cb556517d65bbab5a891be46ed7a781c", size = 5485605, upload-time = "2025-09-16T17:02:04.505Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+]
+
 [[package]]
 name = "jaxlib"
 version = "0.7.2"
@@ -1115,15 +956,6 @@ wheels = [
 ]
 
 [[package]]
-name = "joblib"
-version = "1.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/5d/447af5ea094b9e4c4054f82e223ada074c552335b9b4b2d14bd9b35a67c4/joblib-1.5.2.tar.gz", hash = "sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55", size = 331077, upload-time = "2025-08-27T12:15:46.575Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl", hash = "sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241", size = 308396, upload-time = "2025-08-27T12:15:45.188Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1196,6 +1028,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "libtpu"
+version = "0.0.23"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/45/8283688a26b91d7b04552de00c6b17eb855a8204e593cfd0b47a5fa7ea68/libtpu-0.0.23-cp311-cp311-manylinux_2_31_x86_64.whl", hash = "sha256:2681287cb0bd45e1c9c67e377c4d1d9eca5a41955fc8b8c03acb58b6e0b48ce7", size = 155127454, upload-time = "2025-09-12T21:19:02.282Z" },
+    { url = "https://files.pythonhosted.org/packages/41/69/e5c2a6fc622eec8aed70cd86441bb18e60fd4946dcbec2cf12923cf6a290/libtpu-0.0.23-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:e633423474d8dfec61ee6b282a89f4470172bf6d317cfe6e54ef9da221125074", size = 155127197, upload-time = "2025-09-12T21:19:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/81/de/a1abb348faa4cab7fd07c0762328c5c7aaa4e4f98413c6fe3724d2217fa5/libtpu-0.0.23-cp313-cp313-manylinux_2_31_x86_64.whl", hash = "sha256:5c8b2a7c98afdfe88d712356023bbe594253b468b31aa2be8a88848a1f560a04", size = 155127356, upload-time = "2025-09-12T21:18:33.791Z" },
+    { url = "https://files.pythonhosted.org/packages/de/10/3b52120060de97384055ca42915ab452494bd04440d58e1b0512c11fa068/libtpu-0.0.23-cp313-cp313t-manylinux_2_31_x86_64.whl", hash = "sha256:d6e875ba793907169de2cbdb8c0832508bb4e7e210c0dcd07b9f3a8484657c1b", size = 155127879, upload-time = "2025-09-12T21:18:45.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b1/27322ddf7bfc6854d6703b60369d81916d8f568791e4512e7f7e227e441e/libtpu-0.0.23-cp314-cp314-manylinux_2_31_x86_64.whl", hash = "sha256:7e327e5c02c677ece76374ae680567282f7d5e5aa7fe513c49a3bacc9099af60", size = 155127561, upload-time = "2025-09-12T21:18:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/1ea05fd6b72dfdd60718470474a36fb325b28eb740fd93c37d7c38b92e0b/libtpu-0.0.23-cp314-cp314t-manylinux_2_31_x86_64.whl", hash = "sha256:f1206abe1805690cdeeb27e827a93fd09f803cf05cbd8108e36ffa506935e815", size = 155127695, upload-time = "2025-09-12T21:19:19.669Z" },
 ]
 
 [[package]]
@@ -1309,29 +1154,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdtraj"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pyparsing" },
-    { name = "scipy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/87/04f21b321e7bb6f3e09b5339df51699b8caae4846796175845bbc44f298b/mdtraj-1.11.0.tar.gz", hash = "sha256:2cf0ed2ee9a603dc4599743b1806e1387c655e2a1e9d013841b99fb137ad852e", size = 2860049, upload-time = "2025-06-25T02:06:19.716Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/bc/1a6d273467a24dad5048bf527288a7bbe997ecee8342f6e8fdd7465c9132/mdtraj-1.11.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a6bbf2bc03a2ed23fd1fe696f6f6f970f495e843f3baaa71a0e99da086420de1", size = 2463123, upload-time = "2025-06-25T02:03:06.602Z" },
-    { url = "https://files.pythonhosted.org/packages/09/dc/37bd8a22c66d05a293979d8d8cf1de5e6c03d21ebd6950b6a839c8d8a16b/mdtraj-1.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c34002c49282d208fdd34cd1b2578859bc7377a22ebd66a194efa1fc17395e5", size = 8023237, upload-time = "2025-06-25T02:03:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/6fc195907c056df9b6ff6442bb39c5dd433b971b9deaecf6d18a0761efa8/mdtraj-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:4c794aac3db13937ed7e4f8c2b773564a89b2b539c15f43bae9dab6e1ffa5de1", size = 1355146, upload-time = "2025-06-25T02:03:31.524Z" },
-    { url = "https://files.pythonhosted.org/packages/21/71/56adb24577052f2cd6f9b678da908e8e2d7963db3a88faff39792be43903/mdtraj-1.11.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:878fb8e62962b881ba75d4200637280b518e891e4aa5f213052ddb1905704558", size = 2448664, upload-time = "2025-06-25T02:03:43.052Z" },
-    { url = "https://files.pythonhosted.org/packages/50/af/7d65be36619befb29b51b6118a97121de6685720af7f4cfd6ff1902ca7eb/mdtraj-1.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01eb00d9b62f22056303fb8e4be0f85257a2ce1003f1e6274393bbcc977badaf", size = 8028112, upload-time = "2025-06-25T02:04:12.949Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8f/fd05aa3613fad29b3a779e3384797d2b64aa329bcfd18d25f8fb9c0d725e/mdtraj-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:f87117f7e6742b11a3a39e55fe5c9b4fc013d27691ac671bcc6dfb8193beae0f", size = 1341985, upload-time = "2025-06-25T02:04:19.133Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8f/adbeabf14f27a2befd021548c5d8e696ca129924e0473863fb0e9e546f27/mdtraj-1.11.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:125db8d7b8f795ed2a771d5d6f419461e2f9dd21ef74d43311570b9dadbf0d46", size = 2432588, upload-time = "2025-06-25T02:04:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/c4/4a2e8db0f24c1deb85f4719d54a0a52c56403e17db61ddd72a95d39e07d6/mdtraj-1.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46def167a429af5834f4f26a80bca372518952519847c1ceffd0163814b1164e", size = 7983336, upload-time = "2025-06-25T02:04:57.022Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/17/239ae1869fa0f6fe11e42388f5d1e094ac774f4d122767722f0451523989/mdtraj-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ad81b0aabf090b1b0e60ee7974bd676046e48d35a7efdc9a37a8eacaf5b70e4", size = 1340489, upload-time = "2025-06-25T02:05:04.776Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,15 +1197,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/21/783dfb51f40d2660afeb9bccf3612b99f6a803d980d2a09132b0f9d216ab/ml_dtypes-0.5.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3", size = 689324, upload-time = "2025-07-29T18:39:07.567Z" },
     { url = "https://files.pythonhosted.org/packages/09/f7/a82d249c711abf411ac027b7163f285487f5e615c3e0716c61033ce996ab/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19f6c3a4f635c2fc9e2aa7d91416bd7a3d649b48350c51f7f715a09370a90d93", size = 5275917, upload-time = "2025-07-29T18:39:09.339Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3c/541c4b30815ab90ebfbb51df15d0b4254f2f9f1e2b4907ab229300d5e6f2/ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab039ffb40f3dc0aeeeba84fd6c3452781b5e15bef72e2d10bcb33e4bbffc39", size = 5285284, upload-time = "2025-07-29T18:39:11.532Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -1515,15 +1328,6 @@ wheels = [
 ]
 
 [[package]]
-name = "networkx"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1602,6 +1406,143 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/62/208293d7d6b2a8998a4a1f23ac758648c3c32182d4ce4346062018362e29/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8596ba2f8af5f93b01d97563832686d20206d303024777f6dfc2e7c7c3f1850e", size = 14420354, upload-time = "2025-09-09T15:58:52.704Z" },
     { url = "https://files.pythonhosted.org/packages/ed/0c/8e86e0ff7072e14a71b4c6af63175e40d1e7e933ce9b9e9f765a95b4e0c3/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1ec5615b05369925bd1125f27df33f3b6c8bc10d788d5999ecd8769a1fa04db", size = 16760413, upload-time = "2025-09-09T15:58:55.027Z" },
     { url = "https://files.pythonhosted.org/packages/af/11/0cc63f9f321ccf63886ac203336777140011fb669e739da36d8db3c53b98/numpy-2.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2e267c7da5bf7309670523896df97f93f6e469fb931161f483cd6882b3b1a5dc", size = 12971844, upload-time = "2025-09-09T15:58:57.359Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f1/cd42563325fa827f54ff30da05686c747652bdbd4cb5654cea54d7d0ad4f/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a42996943f0cd78ddfd61c8bf59361672a19b63e0491aa22a53d6fe63a3f854a", size = 856490582, upload-time = "2026-07-02T16:21:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/10/13/b8887c869cf2471339a24b60d3c28e761facbb534935f572b61423371abb/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:f424192dd85e7d29f44be18df2dae4c80d32c67a29c0d42f5c283c40cfdf871c", size = 799083985, upload-time = "2026-07-02T16:25:37.467Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.4.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.5.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.10.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/85/b073e54c993cd9f79faa955d7c9bd7356da408935483aebc3cbb53a922ec/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:f208de397e431631eab0eca946444404a495d43a007535baa333d7de9e510ca2", size = 342026203, upload-time = "2026-08-11T23:23:40.509Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/104de52d6368f5b7f886e8fd252e0a438fe73a215e59b1b47f93a80ae2ea/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:f9b1dc3c2a7e20176054144ebb3b32fea83b40402ee5d7ac7045cd11ecc956c0", size = 342105414, upload-time = "2026-08-11T23:24:24.167Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/a1/9ca9cc3338217311cee21f7ba795dad4f38b7a279a6da7d3d549258f60b1/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:98495de30994f1401a12cc8158ffacbeada44579f54185d75665381468056faa", size = 229963056, upload-time = "2026-07-17T19:23:44.067Z" },
+    { url = "https://files.pythonhosted.org/packages/63/03/cde130e3ff706784f9efd47204f299b15113ea08203e98a556603dac245d/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b6d3482d90ea8ba214bc400362297f573257763990a98c9846ec5c786a7227", size = 230171132, upload-time = "2026-07-17T19:25:07.092Z" },
 ]
 
 [[package]]
@@ -1729,12 +1670,17 @@ dependencies = [
     { name = "jax" },
     { name = "jaxtyping" },
     { name = "msgpack-numpy" },
-    { name = "prxteinmpnn" },
     { name = "safetensors" },
     { name = "uuid-utils" },
 ]
 
 [package.optional-dependencies]
+cpu = [
+    { name = "jax" },
+]
+cuda = [
+    { name = "jax", extra = ["cuda12"] },
+]
 dev = [
     { name = "hypothesis" },
     { name = "pytest" },
@@ -1754,6 +1700,9 @@ docs = [
     { name = "sphinx-rtd-theme" },
     { name = "sphinxext-rediraffe" },
 ]
+tpu = [
+    { name = "jax", extra = ["tpu"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1767,11 +1716,13 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.35.3" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.140.2" },
     { name = "jax" },
+    { name = "jax", marker = "extra == 'cpu'" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'" },
+    { name = "jax", extras = ["tpu"], marker = "extra == 'tpu'" },
     { name = "jaxtyping" },
     { name = "msgpack-numpy", specifier = ">=0.4.8" },
     { name = "myst-nb", marker = "extra == 'docs'" },
     { name = "myst-parser", marker = "extra == 'docs'" },
-    { name = "prxteinmpnn", git = "https://github.com/maraxen/prxteinmpnn.git" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.1" },
@@ -1787,7 +1738,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a21" },
     { name = "uuid-utils" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["cuda", "tpu", "cpu", "dev", "docs"]
 
 [[package]]
 name = "protobuf"
@@ -1801,26 +1752,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874, upload-time = "2025-09-11T21:38:35.509Z" },
     { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013, upload-time = "2025-09-11T21:38:37.017Z" },
     { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289, upload-time = "2025-09-11T21:38:41.234Z" },
-]
-
-[[package]]
-name = "prxteinmpnn"
-version = "0.1.0"
-source = { git = "https://github.com/maraxen/prxteinmpnn.git#cceed7e412dc30ac8131c6838e1244082bd17652" }
-dependencies = [
-    { name = "biotite" },
-    { name = "flax" },
-    { name = "foldcomp" },
-    { name = "gmmx" },
-    { name = "grain" },
-    { name = "h5py" },
-    { name = "jax" },
-    { name = "jaxlib" },
-    { name = "jaxtyping" },
-    { name = "joblib" },
-    { name = "mdtraj" },
-    { name = "numpy" },
-    { name = "optax" },
 ]
 
 [[package]]
@@ -1892,15 +1823,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.2.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
 ]
 
 [[package]]
@@ -3037,65 +2959,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
-    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
-    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
-    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
-    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
-    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
-    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Direct `alphex` adoption in `src/proteinsmc/utils/constants.py` — the exact file the original alias-collision bug shipped from (see `.praxia/docs/research/260813_alphabet-provenance-trace.md`). proteinsmc has no proxide dependency by design, so this depends on alphex directly, following asr's precedent.
- `_build_esm_token_map` now delegates to `alphex.perm()` for the unambiguous 20-residue core; indices 20/21 (conflated STOP/UNKNOWN) stay hand-filled — a full delegation there was verified to unconditionally raise `UnmappableSymbolError`, since `alphex.known.ESM_C` declares STOP and UNKNOWN at different indices.
- Includes a cherry-picked prerequisite fix from a sibling branch that main was missing (disambiguates the AF vs MPNN ESM maps, makes the repo installable again).
- Part of a 3-repo ecosystem migration (proxide, proteinsmc, tev_design), independent of the other two.

## Test plan
- [x] `tests/test_alphabet_conformance.py` — 9/9 pass (ported/verified against current main, not blindly re-derived)
- [x] Before/after parity tests on `_build_esm_token_map`, run against unmodified main first to confirm non-tautological, then bit-for-bit after the change
- [x] Full suite: 319 passed, 12 pre-existing unrelated failures (matches documented baseline), no new failures
- [x] `uv run ruff check` / `uv run ty check` clean
- [x] Independently code-reviewed (3 passes); 5 findings fixed: tautological `test_remap_sequences` (now verified to catch a simulated regression of the original bug), dead import, a duplicated literal now derived from `alphex.known.MPNN_20`, a dead constant removed, a fragile test filter replaced with a direct slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)